### PR TITLE
generic mod config menu and exp bars support

### DIFF
--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -1,8 +1,12 @@
-﻿namespace ExperienceUpdates
+﻿using StardewModdingAPI;
+
+namespace ExperienceUpdates
 {
     public class Configuration
     {
-        public int X = 295, Y = 20;
+        //public SButton ToggleText { get; set; } = SButton.X;
         public int TextDurationMS = 4000;
+        public int X = 295, Y = 20;
+        public int offsetX = 0, offsetY = 0;
     }
 }

--- a/src/ExperienceUpdates.csproj
+++ b/src/ExperienceUpdates.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Configuration.cs" />
     <Compile Include="ExperienceCalculator.cs" />
     <Compile Include="ExperienceType.cs" />
+    <Compile Include="GenericModConfigMenuAPI.cs" />
     <Compile Include="ModEntry.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SkillColorHelper.cs" />

--- a/src/GenericModConfigMenuAPI.cs
+++ b/src/GenericModConfigMenuAPI.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
+using System;
+
+namespace SpaceShared.APIs
+{
+    public interface GenericModConfigMenuAPI
+    {
+        void RegisterModConfig(IManifest mod, Action revertToDefault, Action saveToFile);
+
+        void RegisterLabel(IManifest mod, string labelName, string labelDesc);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func< bool > optionGet, Action< bool > optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func< int > optionGet, Action< int > optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func< float > optionGet, Action< float > optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func< string > optionGet, Action< string > optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func< SButton > optionGet, Action< SButton > optionSet);
+
+        void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func< int > optionGet, Action< int > optionSet, int min, int max);
+        void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func< float > optionGet, Action<float> optionSet, float min, float max);
+
+        void RegisterChoiceOption(IManifest mod, string optionName, string optionDesc, Func< string > optionGet, Action< string > optionSet, string[] choices);
+
+        void RegisterComplexOption(IManifest mod, string optionName, string optionDesc,
+                                   Func< Vector2, object, object > widgetUpdate,
+                                   Func< SpriteBatch, Vector2, object, object > widgetDraw,
+                                   Action< object > onSave);
+    }
+}

--- a/src/ModEntry.cs
+++ b/src/ModEntry.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Linq;
 using System.Reflection;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
 using Microsoft.Xna.Framework.Input;
-using SpaceShared;
 using SpaceShared.APIs;
 
 namespace ExperienceUpdates

--- a/src/ModEntry.cs
+++ b/src/ModEntry.cs
@@ -1,5 +1,12 @@
-﻿using StardewModdingAPI;
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using StardewModdingAPI;
 using StardewModdingAPI.Events;
+using StardewValley;
+using Microsoft.Xna.Framework.Input;
+using SpaceShared;
+using SpaceShared.APIs;
 
 namespace ExperienceUpdates
 {
@@ -9,14 +16,108 @@ namespace ExperienceUpdates
         private ExperienceCalculator calculator;
         private TextRenderer renderer;
         public static Configuration Config;
+        public static bool show;
+        public static SButton ToggleText;
+
+        public object instance;
+
+        //285 and 10 are the "best" default distances for the Updates' text in relation to the upper-left most corner of the Experience Bars UI
+        public static int EXPERIENCE_BARS_PIXELS_OFFSETX = 285;
+        public static int EXPERIENCE_BARS_PIXELS_OFFSETY = 10;
 
         public override void Entry(IModHelper helper)
         {
-            Config = helper.ReadConfig<Configuration>();
+            //Checks to see if Experience Bar is loaded/enabled, if not Updates mod doesn't load rest of mod
+            if (Helper.ModRegistry.IsLoaded("spacechase0.ExperienceBars"))
+            {
+                Config = helper.ReadConfig<Configuration>();
+                helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
+                helper.Events.GameLoop.ReturnedToTitle += OnReturnedToTitle;
+                helper.Events.Display.RenderedHud += OnRenderedHud;
 
-            helper.Events.GameLoop.SaveLoaded += this.OnSaveLoaded;
-            helper.Events.GameLoop.ReturnedToTitle += this.OnReturnedToTitle;
-            helper.Events.Display.RenderedHud += this.OnRenderedHud;
+                helper.Events.GameLoop.GameLaunched += onGameLaunched;
+                helper.Events.Input.ButtonPressed += onButtonPressed;
+
+                //Getting Config information directly from Experience Bars
+                try
+                {
+                    instance = Type.GetType("ExperienceBars.Mod, ExperienceBars").GetField("Config", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);
+                }
+                catch (Exception ex)
+                {
+                    Monitor.Log("Exception during experience bar compat: " + ex, LogLevel.Error);
+                }
+
+            } else
+            {
+                Monitor.Log("WARNING: [Experience Bars] is not loaded. Please make sure it is downloaded and enabled in order to use this mod.", LogLevel.Warn);
+                
+            }
+
+        }
+
+        private void onGameLaunched(object sender, GameLaunchedEventArgs e)
+        {
+            if (Helper.ModRegistry.IsLoaded("spacechase0.ExperienceBars"))
+            {
+                try
+                {
+                    //Setting Toggle Button for Updates to Experience Bars' toggle button and then sets visibility to EXP Bars' current setting
+                    var toggleBtn = Helper.Reflection.GetProperty<SButton>(instance, "ToggleBars").GetValue();
+                    ToggleText = toggleBtn;
+
+                    ////This is so that when the mods are loaded, their visibility states are synced (ie both "Bars" and "Updates" being shown/hidden at the same time)
+                    var shown = Helper.Reflection.GetField<bool>(Type.GetType("ExperienceBars.Mod, ExperienceBars"), "show").GetValue();
+                    show = shown;
+
+                    Monitor.Log($"Game Launched: {toggleBtn}/{ToggleText}, {shown}/{show}");
+                }
+                catch (Exception ex)
+                {
+                    Monitor.Log("Exception during experience bar compat: " + ex, LogLevel.Error);
+                }
+
+            }
+
+            //This adds the Generic Mod Config Menu API to Experience Updates and allows updating mod settings without quitting game
+            var capi = Helper.ModRegistry.GetApi<GenericModConfigMenuAPI>("spacechase0.GenericModConfigMenu");
+            if (capi != null)
+            {
+                capi.RegisterModConfig(ModManifest, () => Config = new Configuration(), () => Helper.WriteConfig(Config));
+                capi.RegisterSimpleOption(ModManifest, "UI X Offset", "The offset of the X position of the text on-screen.", () => Config.offsetX, (int val) => Config.offsetX = val);
+                capi.RegisterSimpleOption(ModManifest, "UI Y Offset", "The offset of the Y position of the text on-screen.", () => Config.offsetY, (int val) => Config.offsetY = val);
+                capi.RegisterSimpleOption(ModManifest, "Text Duration", "The time in milliseconds for the numbers animation to perform (4000 = 4 seconds). ", () => Config.TextDurationMS, (int val) => Config.TextDurationMS = val);
+            }
+        }
+
+        /// <summary>Raised after the player presses a button on the keyboard, controller, or mouse.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        public void onButtonPressed(object sender, ButtonPressedEventArgs e)
+        {
+            var toggleBtn = Helper.Reflection.GetProperty<SButton>(instance, "ToggleBars").GetValue();
+            //When Toggle Button for Experience Bars is changed in Generic Mod Config Menu, this checks to make sure the new button is synced with Experience Updates
+            if (Game1.player.currentLocation == null) {
+                if (toggleBtn != ToggleText)
+                {
+                    Monitor.Log("Toggle Buttons not synced! Begin syncing...", LogLevel.Debug);
+                    ToggleText = toggleBtn;
+                }
+            }
+
+            if (e.Button == ToggleText)
+            {
+                if (show && (Game1.GetKeyboardState().IsKeyDown(Keys.LeftShift) || Game1.GetKeyboardState().IsKeyDown(Keys.RightShift)))
+                {
+                    Config.X = (int)e.Cursor.ScreenPixels.X + EXPERIENCE_BARS_PIXELS_OFFSETX + Config.offsetX;
+                    Config.Y = (int)e.Cursor.ScreenPixels.Y + EXPERIENCE_BARS_PIXELS_OFFSETY + Config.offsetY;
+                    Helper.WriteConfig(Config);
+                }
+                else
+                {
+                    show = !show;
+                }
+            }
         }
 
         private void OnReturnedToTitle(object sender, ReturnedToTitleEventArgs e)
@@ -28,13 +129,27 @@ namespace ExperienceUpdates
         private void OnSaveLoaded(object sender, SaveLoadedEventArgs e)
         {
             Monitor.Log("Save loaded, resetting counters");
+
+            var configX = Helper.Reflection.GetField<int>(instance, "X").GetValue();
+            var configY = Helper.Reflection.GetField<int>(instance, "Y").GetValue();
+
+            //Sets text positions according to EXP Bars position, ideal offsets, and player provided additional offsets
+            Config.X = configX + EXPERIENCE_BARS_PIXELS_OFFSETX + Config.offsetX;
+            Config.Y = configY + EXPERIENCE_BARS_PIXELS_OFFSETY + Config.offsetY;
+            Helper.WriteConfig(Config);
+            
+            Monitor.Log($"Save Loaded...\nX: {configX}/{Config.X}, Y: {configY}/{Config.Y}");
+
             Calculator().Reset();
         }
 
         private void OnRenderedHud(object sender, RenderedHudEventArgs e)
         {
+            if (!show || Game1.activeClickableMenu != null || Game1.eventUp || !Context.IsPlayerFree)
+                return;
+
             var textsToRender = Calculator().GetUpdatableTexts();
-            Renderer().Render(textsToRender, NUMBER_OF_SKILLS);
+            Renderer().Render(textsToRender, NUMBER_OF_SKILLS, EXPERIENCE_BARS_PIXELS_OFFSETX, EXPERIENCE_BARS_PIXELS_OFFSETY);
         }
 
         private ExperienceCalculator Calculator()

--- a/src/TextRenderer.cs
+++ b/src/TextRenderer.cs
@@ -13,12 +13,13 @@ namespace ExperienceUpdates
         private const int EXP_BARS_INTERVAL = 40;
         private const int TEXT_WIDTH = 50;
 
-        internal void Render(Dictionary<int, SparklingText> textsToSkill, int skillsNumber)
+        internal void Render(Dictionary<int, SparklingText> textsToSkill, int skillsNumber, int x, int y)
         {
             if (textsToSkill.Count != 0)
             {
-                int offsetY = CalculateYOffset(skillsNumber);
+                int offsetY = CalculateYOffset(skillsNumber, x + ModEntry.Config.offsetX, y + ModEntry.Config.offsetY);
                 int offsetX = CalculateXOffset();
+
                 foreach (var textToSkill in textsToSkill)
                 {
                     textToSkill.Value.draw(Game1.spriteBatch, new Vector2(offsetX, offsetY + textToSkill.Key * EXP_BARS_INTERVAL));
@@ -40,9 +41,12 @@ namespace ExperienceUpdates
             }
         }
 
-        private int CalculateYOffset(int skills)
+        private int CalculateYOffset(int skills, int x, int y)
         {
             int offsetY = ModEntry.Config.Y;
+            //See below for use of offsetX here
+            int offsetX = ModEntry.Config.X;
+
             if (offsetY < 0)
             {
                 int lowestYPixel = Game1.viewport.Height - Math.Abs(offsetY);
@@ -50,7 +54,11 @@ namespace ExperienceUpdates
             }
             else
             {
-                if (Game1.player.currentLocation != null && Game1.player.currentLocation is MineShaft)
+                //Experience Bars' UI only moves in The Mines if the Experience Bar UI itself is within the (25, 75) game region.
+                //If the UI is anywhere else, it does not move the extra 75 pixels.
+                //Added this code to check location of the Update Text (which is ideally 285px from where the EXP Bars are set)
+                if (Game1.player.currentLocation != null && Game1.player.currentLocation is MineShaft &&
+                offsetX <= (25 + x) && offsetY <= 75 + y)
                 {
                     offsetY += MINESHAFT_LEVEL_PIXELS;
                 }


### PR DESCRIPTION
Added code to include Exp Updates mod in generic mod config menu
- Menu only includes animation/duration and X/Y offsets options. Position is now tied to Exp bars' config file

Also added robust Exp Bars functionality: 
- checks for exp bars mod before allowing mod to load; no EXP Bars, EXP Updates won't do anything
- Mod reads bars' config files so that changes to it can be read by mod and applied directly,
- linked to Exp bars' toggle button (bars and update text now toggle on and off using same button. set button on EXP bar's config menu),
- Shift + [ToggleBtn] moves both Exp Bars and Exp Updates together
- synced positions with added option to change offsets, so update text will automatically be next to the exp bars. user can still change positioning in mod config menu but options are in relation to the right side of bars ui instead of entire game window (ie setting X to 15 and Y to 0 will move it 15 pixels to the right and 0 pixels down of the exp bar instead of placing it at location (15, 0) on screen)